### PR TITLE
Reorganize and Add Call for Tutorials

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,74 +1,93 @@
 # main links links
 main:
-  - title: "Welcome"
-    url: /
-
-  - title: "Registration"
-    url: /
-
   - title: "Program"
-    url: /
+    url: /tutorials
 
-  - title: "Contact"
-    url: /
+  # - title: "Registration"
+  #   url: /
 
-  - title: "Sponsors"
-    url: /
+  - title: "Organization"
+    url: /organization
+
+  # - title: "Sponsors"
+  #   url: /
 
 pages:
-  - title: Getting Started
+  - title: Organization
     children:
-      - title: "Quick-Start Guide"
-        url: /docs/quick-start-guide/
-      - title: "Structure"
-        url: /docs/structure/
-      - title: "Installation"
-        url: /docs/installation/
-      - title: "Upgrading"
-        url: /docs/upgrading/
+      - title: "Organizing Committee"
+      - url: /pages/organization.md
 
-  - title: Customization
-    children:
-      - title: "Configuration"
-        url: /docs/configuration/
-      - title: "Navigation"
-        url: /docs/navigation/
-      - title: "UI Text"
-        url: /docs/ui-text/
-      - title: "Authors"
-        url: /docs/authors/
-      - title: "Layouts"
-        url: /docs/layouts/
+  - title: Registration
 
-  - title: Content
-    children:
-      - title: "Working with Posts"
-        url: /docs/posts/
-      - title: "Working with Pages"
-        url: /docs/pages/
-      - title: "Working with Collections"
-        url: /docs/collections/
-      - title: "Helpers"
-        url: /docs/helpers/
-      - title: "Utility Classes"
-        url: /docs/utility-classes/
+  - title: Program
 
-  - title: Extras
-    children:
-      - title: "Stylesheets"
-        url: /docs/stylesheets/
-      - title: "JavaScript"
-        url: /docs/javascript/
+  - title: Contact
 
-  - title: Meta
+  - title: Sponsors
+
+program:
+  - title: Program
     children:
-      - title: "History"
-        url: /docs/history/
-      - title: "Contributing"
-        url: /docs/contributing/
-      - title: "Old 2.2 Docs"
-        url: /docs/docs-2-2/
-      - title: "License"
-        url: /docs/license/
-      - title: "Terms &amp; Privacy Policy"
-        url: /terms/
+      - title: "Main Conference"
+        url:
+      - title: "Workshops"
+        url:
+      - title: "Tutorials"
+        url: /tutorials
+
+  #   children:
+  #     - title: "Quick-Start Guide"
+  #       url: /docs/quick-start-guide/
+  #     - title: "Structure"
+  #       url: /docs/structure/
+  #     - title: "Installation"
+  #       url: /docs/installation/
+  #     - title: "Upgrading"
+  #       url: /docs/upgrading/
+
+  # - title: Customization
+  #   children:
+  #     - title: "Configuration"
+  #       url: /docs/configuration/
+  #     - title: "Navigation"
+  #       url: /docs/navigation/
+  #     - title: "UI Text"
+  #       url: /docs/ui-text/
+  #     - title: "Authors"
+  #       url: /docs/authors/
+  #     - title: "Layouts"
+  #       url: /docs/layouts/
+
+  # - title: Content
+  #   children:
+  #     - title: "Working with Posts"
+  #       url: /docs/posts/
+  #     - title: "Working with Pages"
+  #       url: /docs/pages/
+  #     - title: "Working with Collections"
+  #       url: /docs/collections/
+  #     - title: "Helpers"
+  #       url: /docs/helpers/
+  #     - title: "Utility Classes"
+  #       url: /docs/utility-classes/
+
+  # - title: Extras
+  #   children:
+  #     - title: "Stylesheets"
+  #       url: /docs/stylesheets/
+  #     - title: "JavaScript"
+  #       url: /docs/javascript/
+
+  # - title: Meta
+  #   children:
+  #     - title: "History"
+  #       url: /docs/history/
+  #     - title: "Contributing"
+  #       url: /docs/contributing/
+  #     - title: "Old 2.2 Docs"
+  #       url: /docs/docs-2-2/
+  #     - title: "License"
+  #       url: /docs/license/
+  #     - title: "Terms &amp; Privacy Policy"
+  #       url: /terms/

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -8,6 +8,12 @@ header:
   caption: 'Photo by <a href="http://www.photography.mattfield.com">Matthew Field</a> / <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC BY-SA 3.0</a>'
 excerpt: "July 30-August 4, 2017 <br/> Vancouver, Canada"
 ---
+
+<h2>News</h2>
+
+**October 4, 2016**. EACL/ACL/EMNLP joint call for [tutorials](/tutorials) posted.
+{: .notice--info}
+
 <h2>Welcome!</h2>
 
 The 55th annual meeting of the Association for Computational Linguistics (ACL) will take place in Vancouver, Canada. ACL 2017 will be held at the [Westin Bayshore Hotel](http://www.starwoodhotels.com/westin/property/overview/index.html?propertyID=1080) in downtown Vancouver from July 30th through August 4th, 2017.
@@ -50,44 +56,3 @@ As in previous years, the program of the conference includes poster sessions, tu
         </tr>
     </tbody>
 </table>
-
-<h2>Organizing Committee</h2>
-
-<h3>General Chair</h3>
-Chris Callison-Burch, University of Pennsylvania
-
-<h3>Program Co-Chairs</h3>
-Regina Barzilay, Massachusetts Institute of Technology<br/>
-Min-Yen Kan, National University of Singapore
-
-<h3>Local Organizing Committee</h3>
-Priscilla Rasmussen, ACL<br/>
-Anoop Sarkar, Simon Fraser University
-
-<h3>Workshop Chairs</h3>
-Wei Xu, Ohio State University<br/>
-Jonathan Berant, Tel Aviv University
-
-<h3>Tutorial Chairs</h3>
-Maja Popović, Humboldt-Universität zu Berlin<br/>
-Jordan Boyd-Graber, University of Colorado, Boulder
-
-<h3>Publication Chairs</h3>
-Wei Lu, Singapore University of Technology and Design<br/>
-Sameer Singh, University of California, Irvine<br/>
-Margaret Mitchell, Microsoft Research
-
-<h3>Demonstration Chairs</h3>
-Heng Ji, Rensselaer Polytechnic Institute<br/>
-Mohit Bansal, University of North Carolina, Chapel Hill
-
-<h3>Faculty Advisors to the Student Research Workshop</h3>
-Cecilia Ovesdotter Alm, Rochester Institute of Technology<br/>
-Mark Dredze, Johns Hopkins University<br/>
-Marine Carpuat, University of Maryland, College Park
-
-<h3>Publicity Chair</h3>
-Charley Chan, Bloomberg
-
-<h3>Webmaster &amp; Appmaster</h3>
-Nitin Madnani, Educational Testing Service

--- a/_pages/organization.md
+++ b/_pages/organization.md
@@ -1,0 +1,46 @@
+---
+title: Organizing Committee
+layout: single
+permalink: /organization
+sidebar: false
+---
+{% include base_path %}
+
+<h3>General Chair</h3>
+Chris Callison-Burch, University of Pennsylvania
+
+<h3>Program Co-Chairs</h3>
+Regina Barzilay, Massachusetts Institute of Technology<br/>
+Min-Yen Kan, National University of Singapore
+
+<h3>Local Organizing Committee</h3>
+Priscilla Rasmussen, ACL<br/>
+Anoop Sarkar, Simon Fraser University
+
+<h3>Workshop Chairs</h3>
+Wei Xu, Ohio State University<br/>
+Jonathan Berant, Tel Aviv University
+
+<h3>Tutorial Chairs</h3>
+Maja Popović, Humboldt-Universität zu Berlin<br/>
+Jordan Boyd-Graber, University of Colorado, Boulder
+
+<h3>Publication Chairs</h3>
+Wei Lu, Singapore University of Technology and Design<br/>
+Sameer Singh, University of California, Irvine<br/>
+Margaret Mitchell, Microsoft Research
+
+<h3>Demonstration Chairs</h3>
+Heng Ji, Rensselaer Polytechnic Institute<br/>
+Mohit Bansal, University of North Carolina, Chapel Hill
+
+<h3>Faculty Advisors to the Student Research Workshop</h3>
+Cecilia Ovesdotter Alm, Rochester Institute of Technology<br/>
+Mark Dredze, Johns Hopkins University<br/>
+Marine Carpuat, University of Maryland, College Park
+
+<h3>Publicity Chair</h3>
+Charley Chan, Bloomberg
+
+<h3>Webmaster &amp; Appmaster</h3>
+Nitin Madnani, Educational Testing Service

--- a/_pages/tutorials.md
+++ b/_pages/tutorials.md
@@ -1,0 +1,132 @@
+---
+title: 
+layout: single
+permalink: /tutorials
+sidebar: 
+    nav: "program"
+---
+{% include base_path %}
+
+<h2>Joint Call for Tutorial Proposals: EACL/ACL/EMNLP 2017</h2>
+
+The European Chapter of the Association for Computational Linguistics (EACL), the Association for Computational Linguistics (ACL), and the Conference on Empirical Methods in Natural Language Processing (EMNLP) invite
+proposals for tutorials to be held in conjunction with EACL 2017, ACL 2017, or EMNLP 2017. We  seek proposals for tutorials in all areas of computational linguistics (CL), broadly conceived to include disciplines such as Linguistics,
+Speech, Information Retrieval, Psycholinguistics, and Multimodal Processing.
+
+We particularly welcome:
+
+1. Tutorials which cover advances in newly emerging areas not previously covered in an *ACL related tutorial.
+2. Tutorials which provide introduction to related fields which are relevant for the CL community (e.g. bioinformatics, neuroscience, human language processing, video and image analysis, machine learning techniques).
+
+In order to gather a widespread audience, the experience and qualifications of the instructors will also be taken into account. 
+
+
+<h3>Important Dates</h3>
+
+<table style="width: 80%">
+    <tbody>
+        <tr>
+             <td colspan="3"><strong>Deadlines shared by all 3 conferences</strong></td>
+        </tr>
+        <tr>
+            <td style="width: 40%;">Submission deadline for proposals</td>
+            <td style="width: 30%;">Wednesday</td>
+            <td>November 30, 2016</td>
+        </tr>
+        <tr>
+            <td>Notification of acceptance</td>
+            <td>Friday</td>
+            <td>December 30, 2016</td>
+        </tr>
+        <tr>
+            <td>Tutorial descriptions due</td>
+            <td>Monday</td>
+            <td>January 30, 2017</td>
+        </tr>
+        <tr>
+             <td colspan="3"><strong>EACL 2017</strong></td>
+        </tr>
+        <tr>
+            <td>Tutorial materials due</td>
+            <td>Friday</td>
+            <td>March 3, 2017</td>
+        </tr>
+        <tr>
+            <td>Tutorial dates</td>
+            <td>Monday &ndash; Tuesday</td>
+            <td>April 3 &ndash; April 4, 2017</td>
+        </tr>
+        <tr>
+             <td colspan="3"><strong>ACL 2017</strong></td>
+        </tr>
+        <tr>
+            <td>Tutorial materials due</td>
+            <td>Friday</td>
+            <td>June 30, 2017</td>
+        </tr>
+        <tr>
+            <td>Tutorial date</td>
+            <td>Sunday</td>
+            <td>July 30, 2017</td>
+        </tr>
+        <tr>
+             <td colspan="3"><strong>EMNLP 2017</strong></td>
+        </tr>
+        <tr>
+            <td>Tutorial materials due</td>
+            <td>Friday</td>
+            <td>August 4, 2017</td>
+        </tr>
+        <tr>
+            <td>Tutorial date</td>
+            <td>Sunday</td>
+            <td>September 3, 2017</td>
+        </tr>
+    </tbody>
+</table>
+
+<h3>Venues</h3>
+
+Tutorials will be held at one of the following conference venues:
+
+- [EACL 2017](http://eacl2017.org/index.php/tutorials) is the 15th Conference of the European Chapter of the Association for Computational Linguistics, to be held in Valencia, Spain, 3-7 April 2017. The selected tutorials will be given on the Monday and Tuesday preceding the main conference (3-4 April). 
+- [ACL 2017](http://acl2017.org/tutorials) is the 55th annual meeting of the Association for Computational Linguistics and will take place in Vancouver, Canada, from July 30th through August 4th, 2017. The selected tutorials will be given on 30th July. 
+- EMNLP 2017  is planned for Copenhagen on the 4-6 September 2017. The tutorials will be given on the 3 September. 
+
+<h3>Remuneration</h3>
+
+Remuneration for tutorials is regulated by  ACL policies . Please note that remuneration for tutorial presenters is fixed according to the above policy and does not cover registration fees for the main conference.
+
+<h3>Submission Details</h3>
+
+Proposals for tutorials should contain:
+   
+1. A title and brief description of the tutorial content and its relevance to the CL community (not more than 2 pages).
+2. A brief outline of the tutorial structure showing that the tutorial's core content can be covered in a three-hour slot (excluding a coffee break). In exceptional cases six-hour tutorial slots can be arranged.
+3. The names, postal addresses, phone numbers, and email addresses of the tutorial instructors, including a one-paragraph statement of their research interests and areas of expertise.
+4. A list of previous venues and approximate audience sizes, if the same or a similar tutorial has been given elsewhere; otherwise an estimate of the audience size.
+5. A description of special requirements for technical equipment (e.g. internet access).
+6. A note specifying which venue(s) (EACL/ACL/EMNLP) would be acceptable and/or preferable.
+
+Tutorial proposals should be submitted online by November 30, 2016 through the [START system](https://www.softconf.com/acl2017/tutorial/). Proposals will be reviewed jointly by the Tutorial Co-Chairs of the three conferences.
+
+<h3>Tutorial Speaker Responsibilities</h3>
+
+Accepted tutorial speakers will be notified by December 30, 2016, and must then provide descriptions of their tutorials for inclusion in the conference registration material by January 30, 2017. The description should be in two formats:  (a) an ASCII version that can be included in email announcements and published on the conference web site, and a (b) PDF version for inclusion in the electronic proceedings (detailed instructions to follow).
+
+Tutorial speakers must provide tutorial course materials, at least containing copies of the course slides as well as a bibliography for the material covered in the tutorial, by the deadlines specified for the three conferences.
+
+<h3>Tutorial Chairs</h3>
+_EACL 2017_<br/>
+Lucia Specia, University of Sheffield<br/>
+Alex Klementiev, Amazon Development Center Germany GmbH
+
+_ACL 2017_<br/>
+Maja Popović, Humboldt-Universität zu Berlin<br/>
+Jordan Boyd-Graber, University of Colorado, Boulder
+
+_EMNLP 2017_<br/>
+Nathan Schneider, Georgetown University
+Alexandra Birch, University of Edinburgh
+
+<h4>Note: Please send all inquiries concerning 2017 tutorials to acl17tutorials (at) gmail (dot) com.</h4>


### PR DESCRIPTION
1. Move organizing committee to its own page.
2. Remove masthead links that do not have any content yet.
3. Add joint call for tutorials under the Program masthead link.
4. Add a News section to home page.