### PR TITLE
Enable program chair blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -159,8 +159,7 @@ defaults:
       author_profile: false
       share: false
       comments: false
-      sidebar:
-        nav: "pages"
+      sidebar: false
   # _posts
   - scope:
       path: ""

--- a/_config.yml
+++ b/_config.yml
@@ -168,7 +168,7 @@ defaults:
     values:
       layout: single
       author_profile: true
-      read_time: true
+      read_time: false
       comments: true
       share: true
       related: true

--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,9 @@ teaser                   : # filename of teaser fallback teaser image placed in 
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:
-  provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", custom"
+  provider               : "disqus" # false (default), "disqus", "discourse", "facebook", "google-plus", custom"
   disqus:
-    shortname            : # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
+    shortname            : "acl2017" # https://help.disqus.com/customer/portal/articles/466208-what-s-a-shortname-
   discourse:
     server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
   facebook:
@@ -161,6 +161,17 @@ defaults:
       comments: false
       sidebar:
         nav: "pages"
+  # _posts
+  - scope:
+      path: ""
+      type: posts
+    values:
+      layout: single
+      author_profile: true
+      read_time: true
+      comments: true
+      share: true
+      related: true
 
 # Outputting
 permalink: /:categories/:title/

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,17 @@
+# Authors
+
+regina:
+  name        : "Regina Barzilay"
+  uri         : "http://people.csail.mit.edu/regina/"
+  email       : "regina@csail.mit.edu​"
+  bio         : "Professor of Electrical Engineering and Computer Science, MIT​."
+  avatar      : "bio-photo.jpg"
+
+knmnyn:
+  name        : "Min-Yen Kan"
+  uri         : "http://www.comp.nus.edu.sg/~kanmy"
+  email       : "kanmy@comp.nus.edu.sg"
+  bio         : "Associate Professor at the National University of Singapore."
+  avatar      : "https://secure.gravatar.com/avatar/85d174cc041ab91e724bb9d9d4e46c88.png?r=PG&s=150"
+  twitter     : "knmnyn"
+  google_plus : "knmnyn"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,6 @@
 # main links links
 main:
-  - title: "Program"
+  - title: "Calls"
     url: /tutorials/
 
   # - title: "Registration"
@@ -21,16 +21,8 @@ pages:
       - title: "Organizing Committee"
       - url: /pages/organization.md
 
-  - title: Registration
-
-  - title: Program
-
-  - title: Contact
-
-  - title: Sponsors
-
 program:
-  - title: Program
+  - title: Calls
     children:
       - title: "Main Conference"
         url:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,13 +1,16 @@
 # main links links
 main:
   - title: "Program"
-    url: /tutorials
+    url: /tutorials/
 
   # - title: "Registration"
   #   url: /
 
   - title: "Organization"
     url: /organization
+
+  - title: "PC Blog"
+    url: /blog
 
   # - title: "Sponsors"
   #   url: /
@@ -34,7 +37,7 @@ program:
       - title: "Workshops"
         url:
       - title: "Tutorials"
-        url: /tutorials
+        url: /tutorials/
 
   #   children:
   #     - title: "Quick-Start Guide"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,7 +10,7 @@ main:
     url: /organization
 
   - title: "PC Blog"
-    url: /blog
+    url: /blog/
 
   # - title: "Sponsors"
   #   url: /

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -35,6 +35,12 @@
     {% if post.read_time %}
       <p class="page__meta"><i class="fa fa-clock-o" aria-hidden="true"></i> {% include read-time.html %}</p>
     {% endif %}
+    {% if post.author and site.data.authors[post.author] %}
+      {% assign author = site.data.authors[post.author] %}
+      <p class="page__meta">{{ author.name }} | {{ post.date | date: "%B %d, %Y" }}</p>
+    {% else %}
+      <p class="page__meta">{{ post.date | date: "%B %d, %Y" }}</p>
+    {% endif %}
     {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
   </article>
 </div>

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -1,0 +1,17 @@
+---
+layout: archive
+permalink: /blog/
+author_profile: false
+sidebar: false
+read_time: false
+share: true
+comments: false
+---
+
+{% include base_path %}
+
+<h3 class="archive__subtitle">Recent Posts</h3>
+
+{% for post in site.posts %}
+  {% include archive-single.html %}
+{% endfor %}

--- a/_pages/archive.md
+++ b/_pages/archive.md
@@ -3,7 +3,6 @@ layout: archive
 permalink: /blog/
 author_profile: false
 sidebar: false
-read_time: false
 share: true
 comments: false
 ---

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -1,0 +1,18 @@
+---
+layout: archive
+permalink: /categories/
+title: "Posts by Category"
+author_profile: false
+sidebar: false
+---
+
+{% include base_path %}
+{% include group-by-array collection=site.posts field="categories" %}
+
+{% for category in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ category | slugify }}" class="archive__subtitle">{{ category }}</h2>
+  {% for post in posts %}
+    {% include archive-single.html %}
+  {% endfor %}
+{% endfor %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,7 +11,7 @@ excerpt: "July 30-August 4, 2017 <br/> Vancouver, Canada"
 
 <h2>News</h2>
 
-**October 4, 2016**. EACL/ACL/EMNLP joint call for [tutorials](/tutorials) posted.
+**October 4, 2016**. EACL/ACL/EMNLP joint call for [tutorials](/tutorials/) posted.
 {: .notice--info}
 
 <h2>Welcome!</h2>

--- a/_pages/organization.md
+++ b/_pages/organization.md
@@ -1,6 +1,7 @@
 ---
 title: Organizing Committee
 layout: single
+excerpt: "ACL 2017 organizing committee."
 permalink: /organization
 sidebar: false
 ---

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,0 +1,18 @@
+---
+layout: archive
+permalink: /tags/
+title: "Posts by Tags"
+author_profile: false
+sidebar: false
+---
+
+{% include base_path %}
+{% include group-by-array collection=site.posts field="tags" %}
+
+{% for tag in group_names %}
+  {% assign posts = group_items[forloop.index0] %}
+  <h2 id="{{ tag | slugify }}" class="archive__subtitle">{{ tag }}</h2>
+  {% for post in posts %}
+    {% include archive-single.html %}
+  {% endfor %}
+{% endfor %}

--- a/_pages/tutorials.md
+++ b/_pages/tutorials.md
@@ -1,7 +1,7 @@
 ---
 title: 
 layout: single
-permalink: /tutorials
+permalink: /tutorials/
 sidebar: 
     nav: "program"
 ---

--- a/_posts/.gitignore
+++ b/_posts/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore


### PR DESCRIPTION
1. Enable blog, add author information, and add archive pages for tags as well as categories.
2. Modify configuration such that both dates and authors of each post are shown on the blog home page. However, in case, the author is not available, we show only the date.
3. Rename `Program` to `Calls` in the masthead since we don't actually have a program yet.
4. Minor updates to permalink and sidebar configurations.

NOTE: to test whether blog posts work as expected:
- Create a plain text file named YEAR-MONTH-DAY-title.md under the `_posts` directory, e.g., `2016-10-05-testing-the-blog.md`.
- Add the following content to the file:

```
---
layout: single
title: "Post: Notice"
categories:
  - Post Formats
tags:
  - Post Formats
  - notice
comments: true
author: knmnyn
read_time: false
---

This is a test.
```

Run `bundle exec jekyll serve` and go to http://127.0.0.1:4000. Click on `PC Blog` and you should see the post headline listed there. Click on that and you should see the full post with Min-Yen's author info.