### PR TITLE
Add call for papers and reorganize a bit.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,6 +97,7 @@ author:
 include:
   - .htaccess
   - _pages
+  - _pages/calls
 exclude:
   - "*.sublime-project"
   - "*.sublime-workspace"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,7 +1,7 @@
 # main links links
 main:
   - title: "Calls"
-    url: /tutorials/
+    url: /calls/papers/
 
   # - title: "Registration"
   #   url: /
@@ -24,12 +24,12 @@ pages:
 program:
   - title: Calls
     children:
-      - title: "Main Conference"
-        url:
+      - title: "Papers"
+        url: /calls/papers/
       - title: "Workshops"
         url:
       - title: "Tutorials"
-        url: /tutorials/
+        url: /calls/tutorials/
 
   #   children:
   #     - title: "Quick-Start Guide"

--- a/_pages/calls/papers.md
+++ b/_pages/calls/papers.md
@@ -1,0 +1,191 @@
+---
+title: 
+layout: single
+permalink: /calls/papers/
+sidebar: 
+    nav: "program"
+---
+{% include base_path %}
+
+{% include toc icon="gears" %}
+
+<span style="font-weight: bolder;font-size: larger;">Call For Papers</span>
+
+The ACL 2017 conference invites the submission of long and short papers on substantial, original, and unpublished research in all aspects of automated language processing. As in recent years, some of the presentations at the conference will be of papers accepted by the [Transactions of the ACL](http://www.transacl.org/) journal.
+
+ACL 2017 has the goal of a broad technical program. Relevant topics
+for the conference include, but are not limited to, the following
+areas (in alphabetical order):
+
+- Cognitive modeling and psycholinguistics
+- Dialog and interactive systems
+- Discourse and pragmatics
+- Document analysis including text categorization, topic models, and retrieval
+- Generation
+- Information extraction, text mining, and question answering
+- Machine learning
+- Machine translation
+- Multilinguality
+- Phonology, morphology, and word segmentation
+- Resources and evaluation
+- Semantics
+- Sentiment analysis and opinion mining
+- Social media
+- Speech
+- Summarization
+- Tagging, chunking, syntax, and parsing
+- Vision, robots, and other grounding
+
+## Important Dates
+
+<table style="width: 90%">
+    <tbody>
+        <tr>
+            <td style="width: 40%;">Submission Deadline (<i>Long &amp; Short Papers)</i></td>
+            <td style="width: 30%;">Monday</td>
+            <td>February 6, 2017</td>
+        </tr>
+        <tr>
+            <td>Author Response Period</td>
+            <td>Monday &ndash; Wednesday</td>
+            <td>March 13 &ndash; March 15, 2017</td>
+        </tr>
+        <tr>
+            <td>Notification of Acceptance</td>
+            <td>Thursday</td>
+            <td>March 30, 2017</td>
+        </tr>
+        <tr>
+          <td>Camera Ready Due</td>
+          <td>Saturday</td>
+          <td>April 15, 2017</td>
+        </tr>
+    </tbody>
+</table>
+
+<h5>Note: All deadlines are 11:59PM Pacific Time.</h5>
+
+## Tutorials
+For tutorial submissions, please see the [call for tutorials](/calls/tutorials).
+
+## Submissions
+
+### Long Papers
+
+Long ACL 2017 submissions must describe substantial, original,
+completed and unpublished work. Wherever appropriate, concrete
+evaluation and analysis should be included. Review forms will be
+made available prior to the deadlines.
+
+Long papers may consist of up to eight (8) pages of content, plus
+unlimited references; final versions of long papers will be given
+one additional page of content (up to 9 pages) so that reviewers'
+comments can be taken into account.
+
+Long papers will be presented orally or as posters as determined by
+the program committee. The decisions as to which papers will be
+presented orally and which as poster presentations will be based on
+the nature rather than the quality of the work. There will be no
+distinction in the proceedings between long papers presented orally
+and as posters.
+
+### Short Papers
+
+ACL 2017 also solicits short papers. Short paper submissions must
+describe original and unpublished work. Please note that a short
+paper is not a shortened long paper. Instead short papers should
+have a point that can be made in a few pages. Some kinds of short
+papers are:
+
+- A small, focused contribution
+- Work in progress
+- A negative result
+- An opinion piece
+- An interesting application nugget
+
+Short papers may consist of up to four (4) pages of content, plus
+unlimited references. Upon acceptance, short papers will be given
+five (5) content pages in the proceedings. Authors are encouraged to
+use this additional page to address reviewers comments in their
+final versions.
+
+Short papers will be presented in one or more oral or poster
+sessions. While short papers will be distinguished from long papers
+in the proceedings, there will be no distinction in the proceedings
+between short papers presented orally and as posters.
+
+## General Notes
+
+Papers should not refer, for further detail, to documents that are
+not available to the reviewers. Papers may be accompanied by a
+resource (software and/or data) described in the paper. Papers that
+are submitted with accompanying software/data may receive additional
+credit toward the overall evaluation score, and the potential impact
+of the software and data will be taken into account when making the
+acceptance/rejection decisions.
+
+ACL 2017 also encourages the submission of supplementary material to
+report preprocessing decisions, model parameters, and other details
+necessary for the replication of the experiments reported in the
+paper. Seemingly small preprocessing decisions can sometimes make a
+large difference in performance, so it is crucial to record such
+decisions to precisely characterize state-of-the-art methods.
+
+Nonetheless, supplementary material should be supplementary (rather
+than central) to the paper. It may include explanations or details
+of proofs or derivations that do not fit into the paper, lists of
+features or feature templates, sample inputs and outputs for a
+system, pseudo-code or source code, and data. The paper should not
+rely on the supplementary material: while the paper may refer to and
+cite the supplementary material and the supplementary material will
+be available to reviewers, they will not be asked to review or even
+download the supplementary material. Authors should refer to the
+contents of the supplementary material in the paper submission, so
+that reviewers interested in these supplementary details will know
+where to look.
+
+As the reviewing will be blind, papers must not include authors'
+names and affiliations. Furthermore, self-references that reveal the
+author's identity, e.g., _"We previously showed (Smith, 1991) ..."_
+must be avoided. Instead, use citations such as _"Smith previously
+showed (Smith, 1991) ..."_ Papers that do not conform to these
+requirements will be rejected without review.
+
+### Electronic Submission
+
+Submission is electronic, using the Softconf START conference
+management system at:
+
+- [https://www.softconf.com/acl2017/papers](https://www.softconf.com/acl2017/papers)  - for long papers
+
+- [https://www.softconf.com/acl2017/shortpapers](https://www.softconf.com/acl2017/shortpapers) - for short papers.
+
+Long paper submissions must follow the two-column format of ACL 2017 proceedings without exceeding eight (8) pages of content. References do not count against this limit. Short paper submissions must also follow the two-column format of ACL 2017 proceedings, and must not exceed four (4) pages.  We strongly recommend the use of ACL LaTeX style files tailored for this year's conference. Submissions must conform to the official style guidelines, which are contained in the style files, and they must be in PDF.
+
+Style files and other information about paper formatting
+requirements will be made available on this website.
+
+
+###  Multiple Submission Policy
+
+Papers that have been or will be submitted to other meetings or publications must indicate this at submission time, and must be withdrawn from the other venues if accepted by ACL 2017. Authors of papers accepted for presentation at ACL 2017 must notify the program chairs by the camera-ready deadline as to whether the paper will be presented. We will not accept for publication or presentation papers that overlap significantly in content or results with papers that will be (or have been) published elsewhere.
+
+Preprint servers such as [arXiv.org](http://arXiv.org) and workshops that do not have published proceedings are not considered archival for purposes of submission. Authors must state in the online submission form the name of the workshop or preprint server and title of the non-archival version. The version submitted for review should be suitably anonymized and not contain references to the prior non-archival version. Reviewers will be told: "The author(s) have notified us that there exists a non-archival previous version of this paper with significantly overlapping text. We have approved submission under these circumstances, but to preserve the spirit of blind review, the current submission does not reference the non-archival version." Reviewers are free to do what they like with this information.
+
+Authors submitting more than one paper to ACL 2017 must ensure that
+submissions do not overlap significantly (>25%) with each other in
+content or results.
+
+### Presentation Requirement
+
+All accepted papers must be presented at the conference to appear in
+the proceedings. At least one author of each accepted paper must
+register for ACL 2017 by the early registration deadline.
+
+## Contact Information
+
+- General chair: Chris Callison-Burch (University of Pennsylvania)
+- Program co-chairs: Regina Barzilay (Massachusetts Institute of
+  Technology) and Min-Yen Kan (National University of Singapore)
+- Email: [acl17pcchairs@gmail.com](mailto:acl17pcchairs@gmail.com)
+

--- a/_pages/calls/tutorials.md
+++ b/_pages/calls/tutorials.md
@@ -1,13 +1,15 @@
 ---
 title: 
 layout: single
-permalink: /tutorials/
+permalink: /calls/tutorials/
 sidebar: 
     nav: "program"
 ---
 {% include base_path %}
 
-<h2>Joint Call for Tutorial Proposals: EACL/ACL/EMNLP 2017</h2>
+{% include toc icon="gears" %}
+
+<span style="font-weight: bolder;font-size: larger;">Joint Call for Tutorial Proposals: EACL/ACL/EMNLP 2017</span>
 
 The European Chapter of the Association for Computational Linguistics (EACL), the Association for Computational Linguistics (ACL), and the Conference on Empirical Methods in Natural Language Processing (EMNLP) invite
 proposals for tutorials to be held in conjunction with EACL 2017, ACL 2017, or EMNLP 2017. We  seek proposals for tutorials in all areas of computational linguistics (CL), broadly conceived to include disciplines such as Linguistics,
@@ -20,8 +22,7 @@ We particularly welcome:
 
 In order to gather a widespread audience, the experience and qualifications of the instructors will also be taken into account. 
 
-
-<h3>Important Dates</h3>
+## Important Dates
 
 <table style="width: 80%">
     <tbody>
@@ -85,7 +86,9 @@ In order to gather a widespread audience, the experience and qualifications of t
     </tbody>
 </table>
 
-<h3>Venues</h3>
+<h5>Note: All deadlines are 11:59PM Pacific Time.</h5>
+
+## Venues
 
 Tutorials will be held at one of the following conference venues:
 
@@ -93,11 +96,11 @@ Tutorials will be held at one of the following conference venues:
 - [ACL 2017](http://acl2017.org/tutorials) is the 55th annual meeting of the Association for Computational Linguistics and will take place in Vancouver, Canada, from July 30th through August 4th, 2017. The selected tutorials will be given on 30th July. 
 - EMNLP 2017  is planned for Copenhagen on the 4-6 September 2017. The tutorials will be given on the 3 September. 
 
-<h3>Remuneration</h3>
+## Remuneration
 
-Remuneration for tutorials is regulated by  ACL policies . Please note that remuneration for tutorial presenters is fixed according to the above policy and does not cover registration fees for the main conference.
+Remuneration for tutorials is regulated by ACL policies . Please note that remuneration for tutorial presenters is fixed according to the above policy and does not cover registration fees for the main conference.
 
-<h3>Submission Details</h3>
+## Submission Details
 
 Proposals for tutorials should contain:
    
@@ -110,13 +113,13 @@ Proposals for tutorials should contain:
 
 Tutorial proposals should be submitted online by November 30, 2016 through the [START system](https://www.softconf.com/g/acl-tutorials2017/). Proposals will be reviewed jointly by the Tutorial Co-Chairs of the three conferences.
 
-<h3>Tutorial Speaker Responsibilities</h3>
+## Tutorial Speaker Responsibilities
 
 Accepted tutorial speakers will be notified by December 30, 2016, and must then provide descriptions of their tutorials for inclusion in the conference registration material by January 30, 2017. The description should be in two formats:  (a) an ASCII version that can be included in email announcements and published on the conference web site, and a (b) PDF version for inclusion in the electronic proceedings (detailed instructions to follow).
 
 Tutorial speakers must provide tutorial course materials, at least containing copies of the course slides as well as a bibliography for the material covered in the tutorial, by the deadlines specified for the three conferences.
 
-<h3>Tutorial Chairs</h3>
+## Tutorial Chairs
 _EACL 2017_<br/>
 Lucia Specia, University of Sheffield<br/>
 Alex Klementiev, Amazon Development Center Germany GmbH
@@ -129,4 +132,4 @@ _EMNLP 2017_<br/>
 Nathan Schneider, Georgetown University
 Alexandra Birch, University of Edinburgh
 
-<h4>Note: Please send all inquiries concerning 2017 tutorials to acl17tutorials (at) gmail (dot) com.</h4>
+<h5>Note: Please send all inquiries concerning 2017 tutorials to acl17tutorials (at) gmail (dot) com.</h5>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,7 +11,11 @@ excerpt: "July 30-August 4, 2017 <br/> Vancouver, Canada"
 
 <h2>News</h2>
 
-**October 4, 2016**. EACL/ACL/EMNLP joint call for [tutorials](/tutorials/) posted.
+**October 20, 2016**. Call for [papers](/calls/papers/) posted.
+{: .notice--info}
+
+
+**October 4, 2016**. EACL/ACL/EMNLP joint call for [tutorials](/calls/tutorials/) posted.
 {: .notice--info}
 
 <h2>Welcome!</h2>


### PR DESCRIPTION
- Move calls for tutorials to subfolder (`/calls/tutorials/`) for URL clarity.
- Add call for papers to `/calls/papers`.
- Update navigation and configuration.
- Add table of contents to both calls for tutorials and papers, for easier navigation since they are long pages.
- Add news notice to home page for call for papers.

Please test to make sure links work okay and also that the text reads fine and has no typos.