### PR TITLE
Add Twitter and Facebook buttons to website footer.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,9 +37,9 @@ yandex_site_verification :
 
 # Social Sharing
 twitter:
-  username               :
+  username               : acl2017
 facebook:
-  username               :
+  username               : acl2017
   app_id                 :
   publisher              :
 og_image                 : # Open Graph/Twitter default site image


### PR DESCRIPTION
**Note**: The share buttons may not show up if you are using an ad blocker.