### PR TITLE
Add page listing workshops and links.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -3,14 +3,20 @@ main:
   - title: "Calls"
     url: /calls/papers/
 
-  # - title: "Registration"
-  #   url: /
+  - title: "Workshops"
+    url: "/workshops"
+
+  # - title: "Tutorials"
+  #   url: "/tutorials"
 
   - title: "Organization"
     url: /organization
 
   - title: "PC Blog"
     url: https://chairs-blog.acl2017.org
+
+  # - title: "Registration"
+  #   url: /registration
 
   # - title: "Sponsors"
   #   url: /
@@ -21,6 +27,11 @@ pages:
       - title: "Organizing Committee"
       - url: /pages/organization.md
 
+  - title: Workshops
+    children:
+      - title: "ACL 2017 Workshops"
+      - url: /pages/workshops.md
+
 program:
   - title: Calls
     children:
@@ -29,7 +40,7 @@ program:
       - title: "Demos"
         url: /calls/demos/
       - title: "Workshops"
-        url:
+        url: /calls/workshops/
       - title: "Tutorials"
         url: /calls/tutorials/
 

--- a/_pages/calls/workshops.md
+++ b/_pages/calls/workshops.md
@@ -1,0 +1,10 @@
+---
+title: 
+layout: single
+permalink: /calls/workshops/
+sidebar: 
+    nav: "program"
+---
+{% include base_path %}
+
+Please visit the individual workshop websites listed [here](/workshops/) for CFPs and paper deadlines.

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,12 +11,16 @@ excerpt: "July 30-August 4, 2017 <br/> Vancouver, Canada"
 
 <h2>News</h2>
 
-**December 1, 2016**. Call for [demos](/calls/demos/) posted.
+**December 20, 2016**. List of [workshops &amp; co-located events](/workshops/) posted.
 {: .notice--info}
+
+
+**December 1, 2016**. Call for [demos](/calls/demos/) posted.
+{: .notice}
 
 
 **October 20, 2016**. Call for [papers](/calls/papers/) posted.
-{: .notice--info}
+{: .notice}
 
 
 <h2>Welcome!</h2>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,7 +11,7 @@ excerpt: "July 30-August 4, 2017 <br/> Vancouver, Canada"
 
 <h2>News</h2>
 
-**December 20, 2016**. List of [workshops &amp; co-located events](/workshops/) posted.
+**December 22, 2016**. List of [workshops &amp; co-located events](/workshops/) posted.
 {: .notice--info}
 
 

--- a/_pages/workshops.md
+++ b/_pages/workshops.md
@@ -8,39 +8,33 @@ sidebar: false
 ---
 {% include base_path %}
 
-Please refer to each individual event's website for its paper deadlines and other details.
-
-- [LaTeCH-CLfL: Joint SIGHUM Workshop on Computational Linguistics for Cultural Heritage, Social Sciences, Humanities and Literature](https://sighum.wordpress.com/events/latech-clfl-2017/)
-
-- [TextGraphs-11: Graph-based Methods for Natural Language Processing](https://sites.google.com/site/textgraphs2017/)
-
-- [Repl4NLP: 2nd Workshop on Representation Learning for NLP](https://sites.google.com/site/repl4nlp2017/)
-
-- [EventStory: Events and Stories in the News](https://sites.google.com/site/eventsandstoriesinthenews/)
-
-- [RoboNLP: Language Grounding for Robotics](https://robonlp2017.github.io)
-
-- [NLP+CSS: Workshops on Natural Language Processing and Computational Social Science](https://sites.google.com/site/nlpandcss/nlp-css-at-acl-2017)
+Please refer to each individual event's website for its paper deadlines and other details. 
 
 - [ALW1: 1st Workshop on Abusive Language Online](https://sites.google.com/site/abusivelanguageworkshop2017/)
-
-- [CLPsych: Computational Linguistics and Clinical Psychology — 
-From Linguistic Signal to Clinical Reality](http://clpsych.org)
-
-- [NMT: 1st Workshop on Neural Machine Translation](https://sites.google.com/site/acl17nmt/)
-
-- [SRW: ACL Student Research Workshop](https://sites.google.com/site/aclsrw2017/)
 
 - BUCC: 10th Workshop on Building and Using Comparable Corpora 
 
 - BioNLP: Workshop on Biomedical Natural Language Processing
 
-- [SemEval: 11th International Workshop on Semantic Evaluation](http://alt.qcri.org/semeval2017/)
+- [CoNLL: The SIGNLL Conference on Computational Natural Language Learning](http://www.conll.org)
+
+- [EventStory: Events and Stories in the News](https://sites.google.com/site/eventsandstoriesinthenews/)
+
+- [LaTeCH-CLfL: Joint SIGHUM Workshop on Computational Linguistics for Cultural Heritage, Social Sciences, Humanities and Literature](https://sighum.wordpress.com/events/latech-clfl-2017/)
+
+- [NLP+CSS: Workshops on Natural Language Processing and Computational Social Science](https://sites.google.com/site/nlpandcss/nlp-css-at-acl-2017)
+
+- [NMT: 1st Workshop on Neural Machine Translation](https://sites.google.com/site/acl17nmt/)
+
+- [Repl4NLP: 2nd Workshop on Representation Learning for NLP](https://sites.google.com/site/repl4nlp2017/)
+
+- [RoboNLP: Language Grounding for Robotics](https://robonlp2017.github.io)
 
 - [*SEM: Sixth Joint Conference On Lexical And Computational Semantics](https://sites.google.com/site/carabirubi3251651561/)
 
-- [CoNLL: The SIGNLL Conference on Computational Natural Language Learning](http://www.conll.org)
+- [SemEval: 11th International Workshop on Semantic Evaluation](http://alt.qcri.org/semeval2017/)
 
+- [SRW: ACL Student Research Workshop](https://sites.google.com/site/aclsrw2017/)
 
-
+- [TextGraphs-11: Graph-based Methods for Natural Language Processing](https://sites.google.com/site/textgraphs2017/)
 

--- a/_pages/workshops.md
+++ b/_pages/workshops.md
@@ -1,0 +1,46 @@
+---
+title: Workshops &amp; Co-located Events
+layout: single
+excerpt: "ACL 2017 Workshops and other Co-located Events ."
+permalink: /workshops/
+sidebar: false
+
+---
+{% include base_path %}
+
+Please refer to each individual event's website for its paper deadlines and other details.
+
+- [LaTeCH-CLfL: Joint SIGHUM Workshop on Computational Linguistics for Cultural Heritage, Social Sciences, Humanities and Literature](https://sighum.wordpress.com/events/latech-clfl-2017/)
+
+- [TextGraphs-11: Graph-based Methods for Natural Language Processing](https://sites.google.com/site/textgraphs2017/)
+
+- [Repl4NLP: 2nd Workshop on Representation Learning for NLP](https://sites.google.com/site/repl4nlp2017/)
+
+- [EventStory: Events and Stories in the News](https://sites.google.com/site/eventsandstoriesinthenews/)
+
+- [RoboNLP: Language Grounding for Robotics](https://robonlp2017.github.io)
+
+- [NLP+CSS: Workshops on Natural Language Processing and Computational Social Science](https://sites.google.com/site/nlpandcss/nlp-css-at-acl-2017)
+
+- [ALW1: 1st Workshop on Abusive Language Online](https://sites.google.com/site/abusivelanguageworkshop2017/)
+
+- [CLPsych: Computational Linguistics and Clinical Psychology — 
+From Linguistic Signal to Clinical Reality](http://clpsych.org)
+
+- [NMT: 1st Workshop on Neural Machine Translation](https://sites.google.com/site/acl17nmt/)
+
+- [SRW: ACL Student Research Workshop](https://sites.google.com/site/aclsrw2017/)
+
+- BUCC: 10th Workshop on Building and Using Comparable Corpora 
+
+- BioNLP: Workshop on Biomedical Natural Language Processing
+
+- [SemEval: 11th International Workshop on Semantic Evaluation](http://alt.qcri.org/semeval2017/)
+
+- [*SEM: Sixth Joint Conference On Lexical And Computational Semantics](https://sites.google.com/site/carabirubi3251651561/)
+
+- [CoNLL: The SIGNLL Conference on Computational Natural Language Learning](http://www.conll.org)
+
+
+
+

--- a/_pages/workshops.md
+++ b/_pages/workshops.md
@@ -14,7 +14,7 @@ Please refer to each individual event's website for its paper deadlines and othe
 
 - BUCC: 10th Workshop on Building and Using Comparable Corpora 
 
-- BioNLP: Workshop on Biomedical Natural Language Processing
+- [BioNLP: Workshop on Biomedical Natural Language Processing](https://www.aclweb.org/aclwiki/index.php?title=SIGBIOMED)
 
 - [CoNLL: The SIGNLL Conference on Computational Natural Language Learning](http://www.conll.org)
 


### PR DESCRIPTION
- Added a tab for "Workshops" to the masthead navigation.
- Added a placeholder page under "Calls -> Workshops" that links to the list of workshop page.
- Added a notice to home page that links to the list of workshop page.